### PR TITLE
Fixed done button on iOS

### DIFF
--- a/components/DoneButton.ios.js
+++ b/components/DoneButton.ios.js
@@ -25,9 +25,7 @@ export const DoneButton = ({
       }]}
       >
         <View style={styles.full}>
-          <Text style={[styles.controllText, {
-            color: rightTextColor, paddingRight: 30,
-          }]}>
+          <Text style={[styles.doneButtonText, { color: rightTextColor }]}>
             {doneBtnLabel}
           </Text>
         </View>
@@ -45,4 +43,3 @@ export const DoneButton = ({
 }
 
 export default DoneButton
-        


### PR DESCRIPTION
It was using wrong style and shifted by 30 for no real reason. If shift is sometimes necessary it can be done in customStyles, but this can not be overridden.